### PR TITLE
Fix new versions of Ollama using CPU instead of GPU due to Slurm issue.

### DIFF
--- a/ollama_batch/batch-ollama-run.sh
+++ b/ollama_batch/batch-ollama-run.sh
@@ -4,7 +4,9 @@
 #SBATCH --nodes 1
 #SBATCH --gpus 1
 #SBATCH --mem 32768
-#SBATCH --job-name ollama-setup
+#SBATCH --job-name ollama-run
+#SBATCH --output=/bask/projects/path/to/logs/ollama-run.out
+#SBATCH --error=/bask/projects/path/to/logs/ollama-run.err 
 
 # Execute using:
 # sbatch ./batch-ollama-run.sh
@@ -36,6 +38,10 @@ export OLLAMA_MODELS=${PWD}/ollama_install/models
 # Want to avoid port conflicts
 export OLLAMA_GAME_PORT=$((21000 + ($RANDOM % 500)))
 export OLLAMA_HOST=127.0.0.1:${OLLAMA_GAME_PORT}
+
+# Slurm incorrectly sets ROCR_VISIBLE_DEVICES=0, which causes Ollama to load models into CPU for inference
+# See https://github.com/ollama/ollama/issues/11220
+unset ROCR_VISIBLE_DEVICES
 
 echo "Ollama host is ${OLLAMA_HOST}"
 


### PR DESCRIPTION
Hi this example was very useful to help me setup Ollama on Baskerville. 

However, after it was set up I ran into an issue where Ollama would load models onto the CPU instead of GPU, even if the GPU resources are available. Issue seems to come from Slurm setting `ROCR_VISIBLE_DEVICES=0` incorrectly, and newer versions of Ollama defaulting to CPU if it is set.

The fix is to `unset ROCR_VISIBLE_DEVICES`. This shouldn't affect affect anything if Ollama or Slurm patches the issue, as Baskerville has no AMD resources anyway.

See [https://github.com/ollama/ollama/issues/11220](https://github.com/ollama/ollama/issues/11220) for more details.